### PR TITLE
Docker Compose v2 Adjustments

### DIFF
--- a/app/jobs/fhir_upload_job.rb
+++ b/app/jobs/fhir_upload_job.rb
@@ -15,10 +15,10 @@ class FhirUploadJob < ActiveJob::Base
       upload_executable = "bin/upload-mac"
     end
 
-    if ENV["IE_PORT_3001_TCP_ADDR"].nil?
+    if ENV["FHIR_URL"].nil?
       fhir_server_url = "http://localhost:3001"
     else
-      fhir_server_url = "http://" + ENV["IE_PORT_3001_TCP_ADDR"] + ":" + ENV["IE_PORT_3001_TCP_PORT"]
+      fhir_server_url = ENV["FHIR_URL"]
     end
 
     `#{upload_executable} -f #{fhir_server_url} -s #{json_file.path} -c`


### PR DESCRIPTION
Use FHIR_URL environment variable to support new docker-compose v2 file.  Switching to docker-compose v2 addresses open issue IE-32.
