### PR TITLE
Infer encounter codes

### DIFF
--- a/app/controllers/ccda_controller.rb
+++ b/app/controllers/ccda_controller.rb
@@ -15,9 +15,40 @@ class CcdaController < ApplicationController
       if doc.at_xpath("/cda:ClinicalDocument/cda:templateId[@root='2.16.840.1.113883.3.88.11.32.1']")
           patient_data =  HealthDataStandards::Import::C32::PatientImporter.instance.parse_c32(doc)
       elsif doc.at_xpath("/cda:ClinicalDocument/cda:templateId[@root='2.16.840.1.113883.10.20.22.1.2']")
+          # Fix encounter codes that have null code but predictable originalText
+          enc_codes = doc.xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section/cda:entry/cda:encounter/cda:code")
+          enc_codes.each do | enc_code |
+            if !enc_code.nil? && enc_code['nullFlavor'] == "UNK" && enc_code['code'].nil?
+              original_text = enc_code.at_xpath("cda:originalText").text
+              case original_text
+              when 'Emergency'
+                enc_code.delete 'nullFlavor'
+                enc_code['code'] = '50849002'
+                enc_code['codeSystem'] = '2.16.840.1.113883.6.96'
+                enc_code['codeSystemName'] = 'SNOMED-CT'
+                enc_code['displayName'] = 'Emergency room admission'
+              when 'Inpatient'
+                enc_code.delete 'nullFlavor'
+                enc_code['code'] = '32485007'
+                enc_code['codeSystem'] = '2.16.840.1.113883.6.96'
+                enc_code['codeSystemName'] = 'SNOMED-CT'
+                enc_code['displayName'] = 'Hospital admission'
+              when 'Observation'
+                enc_code.delete 'nullFlavor'
+                enc_code['code'] = '448951000124107'
+                enc_code['codeSystem'] = '2.16.840.1.113883.6.96'
+                enc_code['codeSystemName'] = 'SNOMED-CT'
+                enc_code['displayName'] = 'Admission to observation unit'
+              else
+                puts "Cannot infer encounter code from unrecognized originalText: #{original_text}"
+              end
+            end
+          end
           patient_data =  HealthDataStandards::Import::CCDA::PatientImporter.instance.parse_ccda(doc)
       end
     end
+
+    # TODO: Fix encounter codes that have no code
 
     patient_json = patient_data.to_json
 

--- a/app/controllers/ccda_controller.rb
+++ b/app/controllers/ccda_controller.rb
@@ -19,29 +19,7 @@ class CcdaController < ApplicationController
           enc_codes = doc.xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section/cda:entry/cda:encounter/cda:code")
           enc_codes.each do | enc_code |
             if !enc_code.nil? && enc_code['nullFlavor'] == "UNK" && enc_code['code'].nil?
-              original_text = enc_code.at_xpath("cda:originalText").text
-              case original_text
-              when 'Emergency'
-                enc_code.delete 'nullFlavor'
-                enc_code['code'] = '50849002'
-                enc_code['codeSystem'] = '2.16.840.1.113883.6.96'
-                enc_code['codeSystemName'] = 'SNOMED-CT'
-                enc_code['displayName'] = 'Emergency room admission'
-              when 'Inpatient'
-                enc_code.delete 'nullFlavor'
-                enc_code['code'] = '32485007'
-                enc_code['codeSystem'] = '2.16.840.1.113883.6.96'
-                enc_code['codeSystemName'] = 'SNOMED-CT'
-                enc_code['displayName'] = 'Hospital admission'
-              when 'Observation'
-                enc_code.delete 'nullFlavor'
-                enc_code['code'] = '448951000124107'
-                enc_code['codeSystem'] = '2.16.840.1.113883.6.96'
-                enc_code['codeSystemName'] = 'SNOMED-CT'
-                enc_code['displayName'] = 'Admission to observation unit'
-              else
-                puts "Cannot infer encounter code from unrecognized originalText: #{original_text}"
-              end
+              self.fix_encounter_code(enc_code)
             end
           end
           patient_data =  HealthDataStandards::Import::CCDA::PatientImporter.instance.parse_ccda(doc)
@@ -60,4 +38,30 @@ class CcdaController < ApplicationController
     render nothing: true
   end
 
+  def fix_encounter_code(enc_code)
+    text = enc_code.parent.at_xpath("cda:text")
+    original_text = enc_code.at_xpath("cda:originalText").text
+    case original_text
+    when 'Emergency'
+      insert_code(enc_code, '50849002', text, original_text)
+    when 'Inpatient'
+      insert_code(enc_code, '32485007', text, original_text)
+    when 'Observation'
+      insert_code(enc_code, '448951000124107', text, original_text)
+    else
+      puts "Cannot infer encounter code from unrecognized originalText: #{original_text}"
+    end
+  end
+
+  def insert_code(code_node, code, text_node, description)
+    code_node.delete 'nullFlavor'
+    code_node['code'] = code
+    code_node['codeSystem'] = '2.16.840.1.113883.6.96'
+    code_node['codeSystemName'] = 'SNOMED-CT'
+    if text_node.nil?
+      code_node.add_next_sibling "<text>#{description}</text>"
+    elsif text_node.content.strip.blank? && text_node.children.empty?
+      text_node.content = description
+    end
+  end
 end


### PR DESCRIPTION
The HIE we are currently integrating with has some CCDA documents that have encounters containing code elements that have no actual _code_, but rather, only have an embedded `originalText` element with one of the following values: `Emergency`, `Inpatient`, `Observation`.

In order to be able to use these encounters in a meaningful way, we detect this situation and apply a corresponding SNOMED-CT code (for emergency room admission, hospital admission, or observation unit admission).  In addition, we populate the encounter's `text` element if it is empty -- so that the HDS import routine gives the encounter an appropriate `description`.

Addresses [IE-10](https://interventionengine.atlassian.net/browse/IE-10)
